### PR TITLE
Replace gradient backgrounds with solid OKLCH palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,26 +3,74 @@
 @tailwind utilities;
 
 :root {
-  --background: 232 46% 5%;
-  --foreground: 215 66% 96%;
-  --muted: 229 32% 14%;
-  --muted-foreground: 218 19% 72%;
-  --popover: 234 52% 7%;
-  --popover-foreground: 215 66% 96%;
-  --card: 233 48% 8%;
-  --card-foreground: 215 66% 96%;
-  --border: 229 32% 20%;
-  --input: 229 32% 20%;
-  --primary: 262 92% 73%;
-  --primary-foreground: 220 100% 98%;
-  --secondary: 196 92% 70%;
-  --secondary-foreground: 217 92% 12%;
-  --accent: 156 86% 52%;
-  --accent-foreground: 220 100% 98%;
-  --destructive: 358 82% 62%;
-  --destructive-foreground: 0 0% 100%;
-  --ring: 262 92% 73%;
-  --radius: 0.9rem;
+  --radius: 0.65rem;
+  --background: 1 0 0;
+  --foreground: 0.141 0.005 285.823;
+  --card: 1 0 0;
+  --card-foreground: 0.141 0.005 285.823;
+  --popover: 1 0 0;
+  --popover-foreground: 0.141 0.005 285.823;
+  --primary: 0.705 0.213 47.604;
+  --primary-foreground: 0.98 0.016 73.684;
+  --secondary: 0.967 0.001 286.375;
+  --secondary-foreground: 0.21 0.006 285.885;
+  --muted: 0.967 0.001 286.375;
+  --muted-foreground: 0.552 0.016 285.938;
+  --accent: 0.967 0.001 286.375;
+  --accent-foreground: 0.21 0.006 285.885;
+  --destructive: 0.577 0.245 27.325;
+  --destructive-foreground: 0.98 0.016 73.684;
+  --border: 0.92 0.004 286.32;
+  --input: 0.92 0.004 286.32;
+  --ring: 0.705 0.213 47.604;
+  --chart-1: 0.646 0.222 41.116;
+  --chart-2: 0.6 0.118 184.704;
+  --chart-3: 0.398 0.07 227.392;
+  --chart-4: 0.828 0.189 84.429;
+  --chart-5: 0.769 0.188 70.08;
+  --sidebar: 0.985 0 0;
+  --sidebar-foreground: 0.141 0.005 285.823;
+  --sidebar-primary: 0.705 0.213 47.604;
+  --sidebar-primary-foreground: 0.98 0.016 73.684;
+  --sidebar-accent: 0.967 0.001 286.375;
+  --sidebar-accent-foreground: 0.21 0.006 285.885;
+  --sidebar-border: 0.92 0.004 286.32;
+  --sidebar-ring: 0.705 0.213 47.604;
+}
+
+.dark {
+  --background: 0.141 0.005 285.823;
+  --foreground: 0.985 0 0;
+  --card: 0.21 0.006 285.885;
+  --card-foreground: 0.985 0 0;
+  --popover: 0.21 0.006 285.885;
+  --popover-foreground: 0.985 0 0;
+  --primary: 0.646 0.222 41.116;
+  --primary-foreground: 0.98 0.016 73.684;
+  --secondary: 0.274 0.006 286.033;
+  --secondary-foreground: 0.985 0 0;
+  --muted: 0.274 0.006 286.033;
+  --muted-foreground: 0.705 0.015 286.067;
+  --accent: 0.274 0.006 286.033;
+  --accent-foreground: 0.985 0 0;
+  --destructive: 0.704 0.191 22.216;
+  --destructive-foreground: 0.985 0 0;
+  --border: 0.985 0 0;
+  --input: 0.985 0 0;
+  --ring: 0.646 0.222 41.116;
+  --chart-1: 0.488 0.243 264.376;
+  --chart-2: 0.696 0.17 162.48;
+  --chart-3: 0.769 0.188 70.08;
+  --chart-4: 0.627 0.265 303.9;
+  --chart-5: 0.645 0.246 16.439;
+  --sidebar: 0.21 0.006 285.885;
+  --sidebar-foreground: 0.985 0 0;
+  --sidebar-primary: 0.646 0.222 41.116;
+  --sidebar-primary-foreground: 0.98 0.016 73.684;
+  --sidebar-accent: 0.274 0.006 286.033;
+  --sidebar-accent-foreground: 0.985 0 0;
+  --sidebar-border: 0.985 0 0;
+  --sidebar-ring: 0.646 0.222 41.116;
 }
 
 @layer base {
@@ -32,43 +80,5 @@
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
-    background-image:
-      radial-gradient(circle at 12% 16%, rgba(129, 140, 248, 0.34), transparent 58%),
-      radial-gradient(circle at 78% 8%, rgba(45, 212, 191, 0.26), transparent 64%),
-      radial-gradient(circle at 65% 92%, rgba(56, 189, 248, 0.22), transparent 70%),
-      linear-gradient(180deg, rgba(15, 23, 42, 0.75), rgba(2, 6, 23, 0.95));
-    background-attachment: fixed;
-  }
-
-  body::before,
-  body::after {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: -1;
-  }
-
-  body::before {
-    background:
-      radial-gradient(circle at 10% 40%, rgba(99, 102, 241, 0.16), transparent 60%),
-      radial-gradient(circle at 88% 12%, rgba(56, 189, 248, 0.18), transparent 62%),
-      linear-gradient(160deg, rgba(30, 41, 59, 0.4), transparent 55%);
-    mix-blend-mode: screen;
-  }
-
-  body::after {
-    background:
-      radial-gradient(circle at 50% 120%, rgba(8, 145, 178, 0.22), transparent 65%),
-      radial-gradient(circle at -10% -20%, rgba(76, 29, 149, 0.2), transparent 60%);
-    opacity: 0.75;
-  }
-}
-
-@layer utilities {
-  .bg-grid {
-    background-image: linear-gradient(rgba(148, 163, 184, 0.05) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(148, 163, 184, 0.05) 1px, transparent 1px);
-    background-size: 60px 60px;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,7 +67,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={cn("dark", fontSans.variable)}>
-      <body className="bg-grid font-sans antialiased">
+      <body className="font-sans antialiased">
         <div className="relative flex min-h-screen flex-col">
           <SiteHeader />
           <main className="flex-1">{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -111,14 +111,7 @@ const faqs = [
 export default function Home() {
   return (
     <div className="space-y-24 pb-24">
-      <section className="relative overflow-hidden pb-16 pt-24">
-        <div className="absolute inset-0 -z-10">
-          <div className="absolute inset-0 bg-hero-grid opacity-60" />
-          <div className="absolute inset-0 bg-hero-aurora opacity-70" />
-          <div className="absolute left-1/2 top-8 h-[560px] w-[560px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(129,140,248,0.28),_transparent_62%)] blur-3xl" />
-          <div className="absolute -left-44 top-24 h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(45,212,191,0.24),_transparent_58%)] blur-3xl" />
-          <div className="absolute -right-36 top-14 h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.22),_transparent_58%)] blur-3xl" />
-        </div>
+      <section className="relative overflow-hidden bg-secondary/15 pb-16 pt-24">
         <div className="container grid gap-16 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
           <div className="space-y-8">
             <Badge className="w-fit border-primary/50 bg-primary/15 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
@@ -155,9 +148,7 @@ export default function Home() {
             </div>
           </div>
           <div className="relative">
-            <div className="absolute inset-0 -z-10 rounded-3xl bg-hero-grid opacity-70" />
-            <Card className="relative h-full min-h-[460px] overflow-hidden border-border/60 bg-card/90 p-0 shadow-card backdrop-blur">
-              <div className="absolute inset-0 bg-[linear-gradient(130deg,_rgba(129,140,248,0.18),_rgba(56,189,248,0.12)_45%,_transparent_80%)]" />
+            <Card className="relative h-full min-h-[460px] overflow-hidden border-border/60 bg-card p-0 shadow-card">
               <div className="relative flex h-full flex-col justify-between p-8">
                 <div className="space-y-6">
                   <div className="flex items-center gap-3 text-sm text-muted-foreground">
@@ -469,7 +460,7 @@ export default function Home() {
       </section>
 
       <section id="contact" className="container">
-        <Card className="overflow-hidden border-border/60 bg-gradient-to-br from-primary/15 via-secondary/12 to-background/80 p-10 backdrop-blur">
+        <Card className="overflow-hidden border-border/60 bg-card/85 p-10 shadow-card backdrop-blur">
           <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
             <div className="space-y-4">
               <Badge variant="outline" className="w-fit border-border/60 text-foreground">

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -22,7 +22,7 @@ export function SiteHeader() {
     <header className="sticky top-0 z-40 w-full border-b border-border/40 bg-background/60 backdrop-blur supports-[backdrop-filter]:bg-background/70">
       <div className="container flex h-16 items-center justify-between gap-6">
         <Link href="#" className="flex items-center gap-2 text-lg font-semibold tracking-tight">
-          <span className="relative inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-primary via-primary/90 to-secondary shadow-glow">
+          <span className="relative inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-primary text-primary-foreground shadow-glow">
             <span className="absolute inset-0 animate-pulse bg-white/15" />
             <span className="relative text-sm font-bold uppercase">OV</span>
           </span>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,10 +9,9 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "bg-gradient-to-r from-primary via-primary/90 to-secondary text-primary-foreground shadow-glow hover:from-primary/90 hover:to-secondary/90",
+        default: "bg-primary text-primary-foreground shadow-glow transition-colors hover:bg-primary/85",
         secondary:
-          "border border-secondary/40 bg-secondary/15 text-secondary-foreground shadow-[0_0_40px_rgba(56,189,248,0.35)] hover:bg-secondary/25",
+          "border border-secondary/40 bg-secondary/20 text-secondary-foreground hover:bg-secondary/30",
         outline:
           "border border-border/60 bg-background/40 backdrop-blur-sm hover:bg-background/60",
         ghost: "hover:bg-foreground/10 hover:text-foreground",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,8 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "relative overflow-hidden rounded-3xl border border-border/50 bg-card/65 p-6 shadow-card backdrop-blur-lg supports-[backdrop-filter]:bg-card/75",
-      "before:pointer-events-none before:absolute before:inset-0 before:-z-10 before:bg-hero-aurora before:opacity-70",
+      "relative overflow-hidden rounded-3xl border border-border/50 bg-card/75 p-6 shadow-card backdrop-blur-lg supports-[backdrop-filter]:bg-card/80",
       className
     )}
     {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,15 +2,8 @@ import type { Config } from "tailwindcss";
 import { fontFamily } from "tailwindcss/defaultTheme";
 import tailwindcssAnimate from "tailwindcss-animate";
 
-const withOpacityValue = (variable: string) => {
-  return ({ opacityValue }: { opacityValue?: string }) => {
-    if (opacityValue !== undefined) {
-      return `oklch(var(${variable}) / ${opacityValue})`;
-    }
-
-    return `oklch(var(${variable}))`;
-  };
-};
+const withOpacityValue = (variable: string) =>
+  `oklch(var(${variable}) / <alpha-value>)`;
 
 const config: Config = {
   darkMode: ["class"],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,16 @@ import type { Config } from "tailwindcss";
 import { fontFamily } from "tailwindcss/defaultTheme";
 import tailwindcssAnimate from "tailwindcss-animate";
 
+const withOpacityValue = (variable: string) => {
+  return ({ opacityValue }: { opacityValue?: string }) => {
+    if (opacityValue !== undefined) {
+      return `oklch(var(${variable}) / ${opacityValue})`;
+    }
+
+    return `oklch(var(${variable}))`;
+  };
+};
+
 const config: Config = {
   darkMode: ["class"],
   content: [
@@ -19,38 +29,38 @@ const config: Config = {
     },
     extend: {
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        border: withOpacityValue("--border"),
+        input: withOpacityValue("--input"),
+        ring: withOpacityValue("--ring"),
+        background: withOpacityValue("--background"),
+        foreground: withOpacityValue("--foreground"),
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: withOpacityValue("--primary"),
+          foreground: withOpacityValue("--primary-foreground"),
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: withOpacityValue("--secondary"),
+          foreground: withOpacityValue("--secondary-foreground"),
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
+          DEFAULT: withOpacityValue("--destructive"),
+          foreground: withOpacityValue("--destructive-foreground"),
         },
         muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
+          DEFAULT: withOpacityValue("--muted"),
+          foreground: withOpacityValue("--muted-foreground"),
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: withOpacityValue("--accent"),
+          foreground: withOpacityValue("--accent-foreground"),
         },
         popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
+          DEFAULT: withOpacityValue("--popover"),
+          foreground: withOpacityValue("--popover-foreground"),
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: withOpacityValue("--card"),
+          foreground: withOpacityValue("--card-foreground"),
         },
       },
       borderRadius: {
@@ -62,17 +72,9 @@ const config: Config = {
         sans: ["var(--font-sans)", ...fontFamily.sans],
         mono: ["JetBrains Mono", ...fontFamily.mono],
       },
-      backgroundImage: {
-        "hero-grid":
-          "radial-gradient(circle at 20% 24%, rgba(129,140,248,0.3), transparent 55%), radial-gradient(circle at 78% 12%, rgba(56,189,248,0.2), transparent 55%), radial-gradient(circle at 58% 88%, rgba(45,212,191,0.22), transparent 60%)",
-        "hero-aurora":
-          "linear-gradient(135deg, rgba(129,140,248,0.12), transparent 45%), radial-gradient(circle at 80% 0%, rgba(56,189,248,0.18), transparent 60%), radial-gradient(circle at -10% 120%, rgba(45,212,191,0.18), transparent 65%)",
-        "accent-glow":
-          "radial-gradient(circle at center, rgba(139,92,246,0.22), transparent 60%)",
-      },
       boxShadow: {
-        glow: "0 0 68px rgba(129,140,248,0.35)",
-        card: "0px 28px 60px -30px rgba(3,7,18,0.66)",
+        glow: "0 0 60px oklch(var(--primary) / 0.35)",
+        card: "0px 28px 60px -30px oklch(var(--foreground) / 0.25)",
       },
       keyframes: {
         "fade-up": {


### PR DESCRIPTION
## Summary
- adopt the provided OKLCH color tokens and remove gradient overlays from the global body styles
- update the Tailwind theme to use OKLCH-based helpers and drop gradient utilities in shared components
- replace hero and contact section gradients with solid surfaces and convert button and header icon styling to solid fills

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e45178ef64832aa134be634310c194